### PR TITLE
Adding num_qubits, num_clbits, etc. getters to Instruction class; add…

### DIFF
--- a/qiskit/circuit/barrier.py
+++ b/qiskit/circuit/barrier.py
@@ -14,9 +14,10 @@
 
 from qiskit.exceptions import QiskitError
 from .instruction import Instruction
+from .operation import Operation
 
 
-class Barrier(Instruction):
+class Barrier(Instruction, Operation):
     """Barrier instruction."""
 
     _directive = True

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -75,9 +75,9 @@ class Instruction:
             raise CircuitError(
                 "bad instruction dimensions: %d qubits, %d clbits." % num_qubits, num_clbits
             )
-        self.name = name
-        self.num_qubits = num_qubits
-        self.num_clbits = num_clbits
+        self._name = name
+        self._num_qubits = num_qubits
+        self._num_clbits = num_clbits
 
         self._params = []  # a list of gate params stored
         # Custom instruction label
@@ -201,6 +201,21 @@ class Instruction:
         pass
 
     @property
+    def name(self):
+        """Return the name."""
+        return self._name
+
+    @property
+    def num_qubits(self):
+        """Return the number of qubits."""
+        return self._num_qubits
+
+    @property
+    def num_clbits(self):
+        """Return the number of clbits."""
+        return self._num_clbits
+
+    @property
     def params(self):
         """return instruction params."""
         return self._params
@@ -213,6 +228,11 @@ class Instruction:
                 self._params.append(single_param)
             else:
                 self._params.append(self.validate_parameter(single_param))
+
+    @property
+    def num_params(self):
+        """Return num_params."""
+        return len(self._params)
 
     def validate_parameter(self, parameter):
         """Instruction parameters has no validation or normalization."""

--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -14,10 +14,11 @@
 Quantum measurement in the computational basis.
 """
 from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.operation import Operation
 from qiskit.circuit.exceptions import CircuitError
 
 
-class Measure(Instruction):
+class Measure(Instruction, Operation):
     """Quantum measurement in the computational basis."""
 
     def __init__(self):

--- a/qiskit/circuit/reset.py
+++ b/qiskit/circuit/reset.py
@@ -14,9 +14,10 @@
 Qubit reset to computational zero.
 """
 from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.operation import Operation
 
 
-class Reset(Instruction):
+class Reset(Instruction, Operation):
     """Qubit reset."""
 
     def __init__(self):


### PR DESCRIPTION
…ing Operation mixing to Barrier, Reset and Measure

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adding Operation mixing to Barrier, Reset and Measure. As these currently still inherit from Instruction, I implemented the required functionality (such as name, num_clbits, etc). in Instruction.

### Details and comments


