### PR TITLE
Fixing name is QuantumCircuit constructor

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -226,6 +226,7 @@ class QuantumCircuit(Operation):
                 )
 
             regs = tuple(int(reg) for reg in regs)  # cast to int
+
         self._base_name = None
         if name is None:
             self._base_name = self.cls_prefix()
@@ -275,7 +276,7 @@ class QuantumCircuit(Operation):
             raise TypeError("Only a dictionary or None is accepted for circuit metadata")
         self._metadata = metadata
 
-        super().__init__(name, len(self._qubits), len(self._clbits), self._parameters)
+        super().__init__(self.name, self.num_qubits, self.num_clbits, self.params)
 
     @property
     def data(self) -> QuantumCircuitData:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

A part of QuantumCircuit __init__ deals with constructing self.name out of name (including the case when the name = None). So, we need to pass that to the __init__ of Operation class. 
Other than that, I liked the previous solution (that uses the property num_qubits instead of len(_qubits) a bit better.

### Details and comments


