### PR TITLE
Circuit element

### DIFF
--- a/qiskit/circuit/barrier.py
+++ b/qiskit/circuit/barrier.py
@@ -24,8 +24,7 @@ class Barrier(Instruction, Operation):
 
     def __init__(self, num_qubits):
         """Create new barrier instruction."""
-        Operation.__init__(self, "barrier", num_qubits, 0, [])
-        Instruction.__init__(self, "barrier", num_qubits, 0, [])
+        super().__init__("barrier", num_qubits, 0, [])
 
     def inverse(self):
         """Special case. Return self."""

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -38,8 +38,7 @@ class Gate(Instruction, Operation):
             label: An optional label for the gate.
         """
         self.definition = None
-        Operation.__init__(self, name, num_qubits, 0, params)
-        Instruction.__init__(self, name, num_qubits, 0, params, label=label)
+        super().__init__(name, num_qubits, 0, params, label=label)
 
     # Set higher priority than Numpy array and matrix classes
     __array_priority__ = 20

--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -23,8 +23,7 @@ class Measure(Instruction, Operation):
 
     def __init__(self):
         """Create new measurement instruction."""
-        Operation.__init__(self, "measure", 1, 1, [])
-        Instruction.__init__(self, "measure", 1, 1, [])
+        super().__init__("measure", 1, 1, [])
 
     def broadcast_arguments(self, qargs, cargs):
         qarg = qargs[0]

--- a/qiskit/circuit/operation.py
+++ b/qiskit/circuit/operation.py
@@ -13,7 +13,7 @@
 """Quantum Operation Mixin."""
 
 from abc import ABC
-
+from qiskit.circuit.exceptions import CircuitError
 
 class Operation(ABC):
     """Quantum Operation Mixin Class.
@@ -23,6 +23,13 @@ class Operation(ABC):
     :class:`~qiskit.circuit.Barrier`, :class:`~qiskit.circuit.Measure`,
     and operators such as :class:`~qiskit.quantum_info.Clifford`.
     """
+
+    def __new__(cls, *args, **kwargs):
+        if cls is Operation:
+            raise CircuitError(
+                "An Operation Mixing should not be instantiated directly."
+            )
+        return super().__new__(cls)
 
     def __init__(self, name, num_qubits, num_clbits, params):
         self._name = name

--- a/qiskit/circuit/operation.py
+++ b/qiskit/circuit/operation.py
@@ -15,6 +15,7 @@
 from abc import ABC
 from qiskit.circuit.exceptions import CircuitError
 
+
 class Operation(ABC):
     """Quantum Operation Mixin Class.
     For objects that can be added to a :class:`~qiskit.circuit.QuantumCircuit`.
@@ -26,9 +27,7 @@ class Operation(ABC):
 
     def __new__(cls, *args, **kwargs):
         if cls is Operation:
-            raise CircuitError(
-                "An Operation Mixing should not be instantiated directly."
-            )
+            raise CircuitError("An Operation Mixing should not be instantiated directly.")
         return super().__new__(cls)
 
     def __init__(self, name, num_qubits, num_clbits, params):

--- a/qiskit/circuit/reset.py
+++ b/qiskit/circuit/reset.py
@@ -22,8 +22,7 @@ class Reset(Instruction, Operation):
 
     def __init__(self):
         """Create new reset instruction."""
-        Operation.__init__(self, "reset", 1, 0, [])
-        Instruction.__init__(self, "reset", 1, 0, [])
+        super().__init__("reset", 1, 0, [])
 
     def broadcast_arguments(self, qargs, cargs):
         for qarg in qargs[0]:

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -93,7 +93,6 @@ class Initialize(Instruction, Operation):
 
             num_qubits = int(num_qubits)
 
-        Operation.__init__(self, "initialize", num_qubits, 0, params)
         super().__init__("initialize", num_qubits, 0, params)
 
     def _define(self):

--- a/qiskit/extensions/quantum_initializer/isometry.py
+++ b/qiskit/extensions/quantum_initializer/isometry.py
@@ -101,7 +101,6 @@ class Isometry(Instruction, Operation):
 
         num_qubits = int(n) + num_ancillas_zero + num_ancillas_dirty
 
-        Operation.__init__(self, "isometry", num_qubits, 0, [isometry])
         super().__init__("isometry", num_qubits, 0, [isometry])
 
     def _define(self):

--- a/qiskit/quantum_info/operators/dihedral/dihedral.py
+++ b/qiskit/quantum_info/operators/dihedral/dihedral.py
@@ -154,8 +154,12 @@ class CNOTDihedral(BaseOperator, AdjointMixin, Operation):
             raise QiskitError("Invalid input type for CNOTDihedral class.")
 
         # Initialize BaseOperator
-        Operation.__init__(self, "CNOTDihedral", self._num_qubits, 0, [])
         super().__init__(num_qubits=self._num_qubits)
+
+        # Initialize Operation
+        self._name = "CNOTDihedral"
+        self._num_clbits = 0
+        self._params = []
 
         # Validate the CNOTDihedral element
         if validate and not self._is_valid():

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -135,8 +135,13 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
                 )
 
         # Initialize BaseOperator
-        Operation.__init__(self, "Clifford", self._table.num_qubits, 0, [])
         super().__init__(num_qubits=self._table.num_qubits)
+
+        # Initialize Operation
+        self._name = "Clifford"
+        self._num_qubits = self._table.num_qubits
+        self._num_clbits = 0
+        self._params = []
 
     def __repr__(self):
         return f"Clifford({repr(self.table)})"

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -202,7 +202,12 @@ class Pauli(BasePauli, Operation):
         if base_z.shape[0] != 1:
             raise QiskitError("Input is not a single Pauli")
         super().__init__(base_z, base_x, base_phase)
-        Operation.__init__(self, "Pauli", self.num_qubits, 0, [])
+
+        # Initialize Operation
+        self._name = "Pauli"
+        self._num_qubits = self.num_qubits
+        self._num_clbits = 0
+        self._params = []
 
     def __repr__(self):
         """Display representation."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Tweaks based on comments from Erik and Eli

### Details and comments

* Based on Eric's suggestion, modified Operation.__new__ to throw a CircuitError when an Operation is instantiated directly

* Eli pointed out that calling Operation.__init__ is bad Python practice. 

So, 
(1) any class that derives from both Instruction and Operation only need to call super(), since Instruction already initializes all relevant fields; 

(2) QuantumCircuit that derives only from Operation calls super().__init__, and this calls Operation's init.

(3) Clifford, CNOTDihedral, Pauli set the fields _name, _num_qubits, _num_clbits directly
