### PR TITLE
Circuit element

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -584,7 +584,7 @@ class C3XGate(ControlledGate):
     This implementation uses :math:`\sqrt{T}` and 14 CNOT gates.
     """
 
-    #pylint: disable=arguments-differ
+    # pylint: disable=arguments-differ
     def __new__(
         cls,
         angle: Optional[ParameterValueType] = None,
@@ -595,7 +595,7 @@ class C3XGate(ControlledGate):
             return C3SXGate(label, ctrl_state, angle=angle)
 
         instance = super().__new__(cls)
-        #pylint: disable=no-value-for-parameter
+        # pylint: disable=no-value-for-parameter
         instance.__init__(None, label, ctrl_state)
         return instance
 
@@ -921,7 +921,7 @@ class C4XGate(ControlledGate):
 class MCXGate(ControlledGate):
     """The general, multi-controlled X gate."""
 
-    #pylint: disable=arguments-differ
+    # pylint: disable=arguments-differ
     def __new__(
         cls,
         num_ctrl_qubits: Optional[int] = None,

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -584,6 +584,7 @@ class C3XGate(ControlledGate):
     This implementation uses :math:`\sqrt{T}` and 14 CNOT gates.
     """
 
+    #pylint: disable=arguments-differ
     def __new__(
         cls,
         angle: Optional[ParameterValueType] = None,
@@ -594,6 +595,7 @@ class C3XGate(ControlledGate):
             return C3SXGate(label, ctrl_state, angle=angle)
 
         instance = super().__new__(cls)
+        #pylint: disable=no-value-for-parameter
         instance.__init__(None, label, ctrl_state)
         return instance
 
@@ -919,6 +921,7 @@ class C4XGate(ControlledGate):
 class MCXGate(ControlledGate):
     """The general, multi-controlled X gate."""
 
+    #pylint: disable=arguments-differ
     def __new__(
         cls,
         num_ctrl_qubits: Optional[int] = None,

--- a/qiskit/circuit/operation.py
+++ b/qiskit/circuit/operation.py
@@ -25,6 +25,7 @@ class Operation(ABC):
     and operators such as :class:`~qiskit.quantum_info.Clifford`.
     """
 
+    # pylint: disable=unused-argument
     def __new__(cls, *args, **kwargs):
         if cls is Operation:
             raise CircuitError("An Operation mixin should not be instantiated directly.")

--- a/test/python/circuit/gate_utils.py
+++ b/test/python/circuit/gate_utils.py
@@ -33,7 +33,7 @@ def _get_free_params(fun, ignore=None):
         if (
             param.default == Parameter.empty
             and param.kind != Parameter.VAR_POSITIONAL
-            and name is not "self"
+            and name != "self"
         ):
             if name not in ignore:
                 free_params.append(name)

--- a/test/python/circuit/test_operation.py
+++ b/test/python/circuit/test_operation.py
@@ -1,0 +1,33 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test Qiskit's Operation class."""
+
+import unittest
+from qiskit.circuit import Operation
+from qiskit.circuit.exceptions import CircuitError
+from qiskit.test import QiskitTestCase
+
+
+class TestOperationClass(QiskitTestCase):
+    """Testing qiskit.circuit.Operation"""
+
+    def test_can_not_instantiate_directly(self):
+        """Test that we cannot instantiate an object of class Operation directly."""
+
+        with self.assertRaises(CircuitError) as exc:
+            Operation("my_operation", 2, 4, [])
+        self.assertIn("should not be instantiated directly", exc.exception.message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixing pylint complaints
Adding test for Operation class to check that an Operation cannot be instantiated directly

### Details and comments

After adding the __new__ method to Operation class, there were several pylint complaints about a derived C3XGate class.

1. A complaint that  C3XGate class also uses __new__ but with different signature. This seemed harmless, and I have added the pylint-disable=arguments-differ message. 

2. A complaint that C3XGate class has no value for argument 'params' when calling super().__init__. I don't fully understand this complaint but checked that the code seems to work fine using step-by-step debugging, so have also added pylint-disable message, but will ask Julien to take another look.
