### PR TITLE
Updating the Operation class following the meeting with the quantum s…

### DIFF
--- a/qiskit/circuit/operation.py
+++ b/qiskit/circuit/operation.py
@@ -12,51 +12,32 @@
 
 """Quantum Operation Mixin."""
 
-from abc import ABC
-from qiskit.circuit.exceptions import CircuitError
+from abc import ABC, abstractmethod
 
 
 class Operation(ABC):
-    """Quantum Operation Mixin Class.
+    """Quantum Operation Interface Class.
     For objects that can be added to a :class:`~qiskit.circuit.QuantumCircuit`.
     These objects include :class:`~qiskit.circuit.Gate`, :class:`~qiskit.circuit.Reset`,
     :class:`~qiskit.circuit.Barrier`, :class:`~qiskit.circuit.Measure`,
     and operators such as :class:`~qiskit.quantum_info.Clifford`.
     """
 
-    # pylint: disable=unused-argument
-    def __new__(cls, *args, **kwargs):
-        if cls is Operation:
-            raise CircuitError("An Operation mixin should not be instantiated directly.")
-        return super().__new__(cls)
-
-    def __init__(self, name, num_qubits, num_clbits, operands):
-        self._name = name
-        self._num_qubits = num_qubits
-        self._num_clbits = num_clbits
-        self._operands = operands
+    __slots__ = ()
 
     @property
+    @abstractmethod
     def name(self):
         """Unique string identifier for operation type."""
-        return self._name
+        raise NotImplementedError
 
     @property
+    @abstractmethod
     def num_qubits(self):
         """Number of qubits."""
-        return self._num_qubits
+        raise NotImplementedError
 
     @property
     def num_clbits(self):
         """Number of classical bits."""
-        return self._num_clbits
-
-    @property
-    def num_operands(self):
-        """Number of operands."""
-        return len(self._operands)
-
-    @property
-    def operands(self):
-        """List of operands to specialize a specific Operation instance."""
-        return self._operands
+        raise NotImplementedError

--- a/qiskit/quantum_info/operators/dihedral/dihedral.py
+++ b/qiskit/quantum_info/operators/dihedral/dihedral.py
@@ -156,14 +156,19 @@ class CNOTDihedral(BaseOperator, AdjointMixin, Operation):
         # Initialize BaseOperator
         super().__init__(num_qubits=self._num_qubits)
 
-        # Initialize Operation
-        self._name = "cnotdihedral"
-        self._num_clbits = 0
-        self._operands = []
-
         # Validate the CNOTDihedral element
         if validate and not self._is_valid():
             raise QiskitError("Invalid CNOTDihedral element.")
+
+    @property
+    def name(self):
+        """Unique string identifier for operation type."""
+        return "cnotdihedral"
+
+    @property
+    def num_clbits(self):
+        """Number of classical bits."""
+        return 0
 
     def _z2matmul(self, left, right):
         """Compute product of two n x n z2 matrices."""

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -137,11 +137,20 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
         # Initialize BaseOperator
         super().__init__(num_qubits=self._table.num_qubits)
 
-        # Initialize Operation
-        self._name = "clifford"
-        self._num_qubits = self._table.num_qubits
-        self._num_clbits = 0
-        self._operands = []
+    @property
+    def name(self):
+        """Unique string identifier for operation type."""
+        return "clifford"
+
+    @property
+    def num_qubits(self):
+        """Number of qubits."""
+        return self._table.num_qubits
+
+    @property
+    def num_clbits(self):
+        """Number of classical bits."""
+        return 0
 
     def __repr__(self):
         return f"Clifford({repr(self.table)})"

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -202,11 +202,15 @@ class Pauli(BasePauli, Operation):
             raise QiskitError("Input is not a single Pauli")
         super().__init__(base_z, base_x, base_phase)
 
-        # Initialize Operation
-        self._name = "pauli"
-        self._num_qubits = self.num_qubits
-        self._num_clbits = 0
-        self._operands = []
+    @property
+    def name(self):
+        """Unique string identifier for operation type."""
+        return "pauli"
+
+    @property
+    def num_clbits(self):
+        """Number of classical bits."""
+        return 0
 
     def __repr__(self):
         """Display representation."""

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -62,6 +62,7 @@ if HAS_FIXTURES:
         assertRaises = unittest.TestCase.assertRaises
         assertEqual = unittest.TestCase.assertEqual
 
+
 else:
 
     class BaseTestCase(unittest.TestCase):

--- a/test/python/circuit/test_operation.py
+++ b/test/python/circuit/test_operation.py
@@ -13,20 +13,166 @@
 """Test Qiskit's Operation class."""
 
 import unittest
-from qiskit.circuit import Operation
-from qiskit.circuit.exceptions import CircuitError
+
+import numpy as np
+
 from qiskit.test import QiskitTestCase
+from qiskit.circuit import QuantumCircuit, Barrier, Measure, Reset, Operation, Gate
+from qiskit.circuit.library import XGate, CXGate
+from qiskit.quantum_info.operators import Clifford, CNOTDihedral, Pauli
+from qiskit.extensions.quantum_initializer import Initialize, Isometry
 
 
 class TestOperationClass(QiskitTestCase):
     """Testing qiskit.circuit.Operation"""
 
-    def test_can_not_instantiate_directly(self):
-        """Test that we cannot instantiate an object of class Operation directly."""
+    def test_operation_cannot_be_instantiated_directly(self):
+        """Test that we cannot instantiate an object of class :class:`~qiskit.circuit.Operation` directly."""
+        with self.assertRaises(TypeError):
+            Operation()
 
-        with self.assertRaises(CircuitError) as exc:
-            Operation("my_operation", 2, 4, [])
-        self.assertIn("should not be instantiated directly", exc.exception.message)
+    def test_measure_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.circuit.Measure` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        op = Measure()
+        self.assertTrue(op.name == "measure")
+        self.assertTrue(op.num_qubits == 1)
+        self.assertTrue(op.num_clbits == 1)
+
+    def test_reset_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.circuit.Reset` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        op = Reset()
+        self.assertTrue(op.name == "reset")
+        self.assertTrue(op.num_qubits == 1)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_barrier_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.circuit.Barrier` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        num_qubits = 4
+        op = Barrier(num_qubits)
+        self.assertTrue(op.name == "barrier")
+        self.assertTrue(op.num_qubits == num_qubits)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_clifford_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.quantum_info.operators.Clifford` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        num_qubits = 4
+        qc = QuantumCircuit(4, 0)
+        qc.h(2)
+        qc.cx(0, 1)
+        op = Clifford(qc)
+        self.assertTrue(op.name == "clifford")
+        self.assertTrue(op.num_qubits == num_qubits)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_cnotdihedral_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.quantum_info.operators.CNOTDihedral` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        num_qubits = 4
+        qc = QuantumCircuit(4)
+        qc.t(0)
+        qc.x(0)
+        qc.t(0)
+        op = CNOTDihedral(qc)
+        self.assertTrue(op.name == "cnotdihedral")
+        self.assertTrue(op.num_qubits == num_qubits)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_pauli_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.quantum_info.operators.Pauli` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        num_qubits = 4
+        op = Pauli("I" * num_qubits)
+        self.assertTrue(op.name == "pauli")
+        self.assertTrue(op.num_qubits == num_qubits)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_isometry_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.extensions.quantum_initializer.Isometry` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        op = Isometry(np.eye(4, 4), 3, 2)
+        self.assertTrue(op.name == "isometry")
+        self.assertTrue(op.num_qubits == 7)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_initialize_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.extensions.quantum_initializer.Initialize` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        desired_vector = [0.5, 0.5, 0.5, 0.5]
+        op = Initialize(desired_vector)
+        self.assertTrue(op.name == "initialize")
+        self.assertTrue(op.num_qubits == 2)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_gate_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.circuit.Gate` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        name = "test_gate_name"
+        num_qubits = 3
+        op = Gate(name, num_qubits, [])
+        self.assertTrue(op.name == name)
+        self.assertTrue(op.num_qubits == num_qubits)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_xgate_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.circuit.library.XGate` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        op = XGate()
+        self.assertTrue(op.name == "x")
+        self.assertTrue(op.num_qubits == 1)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_cxgate_as_operation(self):
+        """Test that we can instantiate an object of class :class:`~qiskit.circuit.library.XGate` and that
+        it has the expected name, num_qubits and num_clbits.
+        """
+        op = CXGate()
+        self.assertTrue(op.name == "cx")
+        self.assertTrue(op.num_qubits == 2)
+        self.assertTrue(op.num_clbits == 0)
+
+    def test_can_append_to_quantum_circuit(self):
+        """Test that we can add various objects with Operation interface to a Quantum Circuit."""
+        qc = QuantumCircuit(6, 1)
+        qc.append(XGate(), [2])
+        qc.append(Barrier(3), [1, 2, 4])
+        qc.append(CXGate(), [0, 1])
+        qc.append(Measure(), [1], [0])
+        qc.append(Reset(), [0])
+        qc.cx(3, 4)
+        qc.append(Gate("some_gate", 3, []), [1, 2, 3])
+        qc.append(Initialize([0.5, 0.5, 0.5, 0.5]), [4, 5])
+        qc.append(Isometry(np.eye(4, 4), 0, 0), [3, 4])
+        qc.append(Pauli("II"), [0, 1])
+
+        # Appending Clifford
+        circ1 = QuantumCircuit(2)
+        circ1.h(1)
+        circ1.cx(0, 1)
+        qc.append(Clifford(circ1), [0, 1])
+
+        # Appending CNOTDihedral
+        circ2 = QuantumCircuit(2)
+        circ2.t(0)
+        circ2.x(0)
+        circ2.t(1)
+        qc.append(CNOTDihedral(circ2), [2, 3])
+
+        # If we got to here, we have successfully appended everything to qc
+        self.assertTrue(True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…ynthesis team; adding tests to test_operation

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Updating the Operation class based on the discussion with the quantum synthesis team and notes from Jake.

Adding tests to test operation that check: 

1. we can instantiate various classes that have `Operation` interface and they have the expected `name`, `num_qubits` and `num_clbits`. 
2. we can add such objects to a `QuantumCircuit`

### Details and comments

The `QuantumCircuit` itself is still not an `Operation`, as we have agreed we will add this functionality when we get a use-case for that.

The soon-to-follow (but a different) PR will be to make `LinearFunction` of type `Operation` and not of type `QuantumCircuit`
